### PR TITLE
feat: Implement Bento Grid 'About Me' section

### DIFF
--- a/client/src/components/sections/AnimatedHero.css
+++ b/client/src/components/sections/AnimatedHero.css
@@ -46,15 +46,90 @@
   color: white;
 }
 
-.about-content {
-  max-width: 800px;
-  padding: 2.5rem;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px); /* For Safari */
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+.bento-grid-container {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    grid-template-rows: auto auto;
+    gap: 1rem;
+    width: 100%;
+    max-width: 900px;
+    padding: 1rem;
+}
+
+.bento-card {
+    background: rgba(20, 20, 20, 0.6);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    text-align: left;
+}
+
+.card-intro {
+    grid-row: span 2;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.headshot {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 1rem;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.card-intro h3 {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.bento-card h4 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.bento-card p,
+.bento-card li {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.card-skills ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.card-skills li {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.3rem 0.75rem;
+    border-radius: 12px;
+    font-size: 0.9rem;
+}
+
+/* Responsive stacking for mobile */
+@media (max-width: 768px) {
+    .bento-grid-container {
+        grid-template-columns: 1fr;
+    }
+
+    .card-intro {
+        grid-row: auto;
+    }
 }
 
 .text-shadow {

--- a/client/src/components/sections/AnimatedHero.jsx
+++ b/client/src/components/sections/AnimatedHero.jsx
@@ -19,9 +19,10 @@ const AnimatedContent = ({ profile }) => {
     const backgroundY = useTransform(scrollYProgress, [0.3, 1], ['0%', '-50%']);
     const introOpacity = useTransform(scrollYProgress, [0, 0.2], [1, 0]);
     const introScale = useTransform(scrollYProgress, [0, 0.2], [1, 0.9]);
-    const aboutOpacity = useTransform(scrollYProgress, [0.15, 0.3, 0.8, 0.95], [0, 1, 1, 0]);
-    const aboutScale = useTransform(scrollYProgress, [0.15, 0.3, 0.8, 0.95], [0.95, 1, 1, 0.95]);
-    const aboutPointerEvents = useTransform(scrollYProgress, [0.14, 0.15, 0.95, 0.96], ['none', 'auto', 'auto', 'none']);
+    const introPointerEvents = useTransform(scrollYProgress, [0.19, 0.2], ['auto', 'none']);
+
+    const aboutOpacity = useTransform(scrollYProgress, [0.2, 0.3, 0.8, 0.95], [0, 1, 1, 0]);
+    const aboutPointerEvents = useTransform(scrollYProgress, [0.19, 0.2, 0.95, 0.96], ['none', 'auto', 'auto', 'none']);
 
     return (
         <div ref={targetRef} id="home" className="animated-hero-container">
@@ -34,7 +35,7 @@ const AnimatedContent = ({ profile }) => {
                 </motion.div>
                 
                 <div className="content-container">
-                    <motion.div className="text-section" style={{ opacity: introOpacity, scale: introScale }}>
+                    <motion.div className="text-section" style={{ opacity: introOpacity, scale: introScale, pointerEvents: introPointerEvents }}>
                         <Container>
                             <h1 className="display-1 fw-bold text-shadow">
                                 {profile?.name ? he.decode(profile.name) : 'Your Name'}
@@ -67,14 +68,47 @@ const AnimatedContent = ({ profile }) => {
                         </Container>
                     </motion.div>
                 
-                    <motion.div id="about" className="text-section" style={{ opacity: aboutOpacity, scale: aboutScale, pointerEvents: aboutPointerEvents }}>
-                        <Container className="about-content">
-                            <h2 className="display-4 fw-bold">About Me</h2>
-                            <hr className="my-4" style={{ width: '60px', height: '3px', margin: 'auto', opacity: 1 }} />
-                            <p className="lead">
-                                {profile?.about ? he.decode(profile.about) : ''}
-                            </p>
-                        </Container>
+                    <motion.div id="about" className="text-section" style={{ opacity: aboutOpacity, pointerEvents: aboutPointerEvents }}>
+                        <motion.div
+                            className="bento-grid-container"
+                            variants={{
+                                hidden: { opacity: 0 },
+                                visible: {
+                                    opacity: 1,
+                                    transition: { staggerChildren: 0.2, delayChildren: 0.1 },
+                                },
+                            }}
+                            initial="hidden"
+                            whileInView="visible"
+                            viewport={{ once: true, amount: 0.2 }}
+                        >
+                            <motion.div className="bento-card card-intro" variants={{ hidden: { y: 20, opacity: 0 }, visible: { y: 0, opacity: 1 } }}>
+                                <img src={profile?.profilePhoto || "https://via.placeholder.com/150"} alt="Headshot" className="headshot" />
+                                <h3>Hello, I’m {profile?.name ? he.decode(profile.name).split(' ')[0] : 'Amaan'}</h3>
+                            </motion.div>
+                            <motion.div className="bento-card card-narrative" variants={{ hidden: { y: 20, opacity: 0 }, visible: { y: 0, opacity: 1 } }}>
+                                <h4>My Journey</h4>
+                                <p>
+                                    {profile?.aboutNarrative || "A passionate developer with a knack for creating dynamic and intuitive web applications. My journey in tech is driven by a love for problem-solving and a desire to build things that make a difference."}
+                                </p>
+                            </motion.div>
+                            <motion.div className="bento-card card-skills" variants={{ hidden: { y: 20, opacity: 0 }, visible: { y: 0, opacity: 1 } }}>
+                                <h4>Core Skills</h4>
+                                <ul>
+                                    {profile?.aboutSkills && profile.aboutSkills.length > 0 ? (
+                                        profile.aboutSkills.map((skill, index) => <li key={index}>{skill}</li>)
+                                    ) : (
+                                        <>
+                                            <li>React</li>
+                                            <li>Node.js</li>
+                                            <li>Express</li>
+                                            <li>MongoDB</li>
+                                            <li>JavaScript</li>
+                                        </>
+                                    )}
+                                </ul>
+                            </motion.div>
+                        </motion.div>
                     </motion.div>
                 </div>
             </div>

--- a/client/src/pages/Admin/ProfileEditPage.jsx
+++ b/client/src/pages/Admin/ProfileEditPage.jsx
@@ -5,7 +5,8 @@ import { getProfile, updateProfile, uploadImages } from '../../api/apiService';
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
-  const [formData, setFormData] = useState({ name: "", headline: "", about: "", profilePhoto: "", resumeUrl: "" });
+  // Update state to match new schema
+  const [formData, setFormData] = useState({ name: "", headline: "", aboutNarrative: "", aboutSkills: [], profilePhoto: "", resumeUrl: "" });
   const [loading, setLoading] = useState(true);
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
   const [error, setError] = useState("");
@@ -14,7 +15,8 @@ const ProfileEditPage = () => {
     const fetchProfile = async () => {
       try {
         const { data } = await getProfile();
-        if (data) setFormData(data);
+        // Ensure skills is an array, even if it's missing
+        if (data) setFormData({ ...data, aboutSkills: data.aboutSkills || [] });
         setLoading(false);
       } catch (err) { setLoading(false); }
     };
@@ -23,6 +25,12 @@ const ProfileEditPage = () => {
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  // Handler for the skills textarea
+  const handleSkillsChange = (e) => {
+    const skillsArray = e.target.value.split(',').map(skill => skill.trim()).filter(skill => skill);
+    setFormData({ ...formData, aboutSkills: skillsArray });
   };
   
   const uploadPhotoHandler = async (e) => {
@@ -62,27 +70,16 @@ const ProfileEditPage = () => {
           <h1>Edit Profile</h1>
           {loading ? <p>Loading...</p> : error ? <Alert variant="danger">{error}</Alert> : (
             <Form onSubmit={handleSubmit}>
-              {/* ...Name, Headline, About, and Photo sections are unchanged... */}
-              <Form.Group className="mb-3" controlId="name"><Form.Label>Full Name</Form.Label><Form.Control type="text" name="name" value={formData.name} onChange={handleChange} required /></Form.Group>
-              <Form.Group className="mb-3" controlId="headline"><Form.Label>Professional Headline</Form.Label><Form.Control type="text" name="headline" value={formData.headline} onChange={handleChange} required /></Form.Group>
-              <Form.Group className="mb-3" controlId="about"><Form.Label>About Me Paragraph</Form.Label><Form.Control as="textarea" rows={5} name="about" value={formData.about} onChange={handleChange} required /></Form.Group>
-              <Form.Group controlId="profilePhoto" className="mb-3"><Form.Label>Profile Photo</Form.Label><Form.Control type="file" onChange={uploadPhotoHandler} accept="image/*" />{uploadingPhoto && <Spinner animation="border" size="sm" className="mt-2" />}</Form.Group>
-              {formData.profilePhoto && (<div className="mb-3"><p>Current Photo:</p><Image src={formData.profilePhoto} thumbnail width="150" /><Button variant="outline-danger" size="sm" className="ms-3" onClick={handlePhotoRemove}>Remove Photo</Button></div>)}
+              <Form.Group className="mb-3" controlId="name"><Form.Label>Full Name</Form.Label><Form.Control type="text" name="name" value={formData.name || ''} onChange={handleChange} required /></Form.Group>
+              <Form.Group className="mb-3" controlId="headline"><Form.Label>Professional Headline</Form.Label><Form.Control type="text" name="headline" value={formData.headline || ''} onChange={handleChange} required /></Form.Group>
 
-              {/* --- RESUME LINK SECTION --- */}
-              <Form.Group className="mb-3" controlId="resumeUrl">
-                <Form.Label>Resume Link (URL)</Form.Label>
-                <Form.Control
-                  type="url"
-                  name="resumeUrl"
-                  value={formData.resumeUrl}
-                  onChange={handleChange}
-                  placeholder="e.g., https://docs.google.com/document/d/..."
-                />
-                <Form.Text className="text-muted">
-                  Paste the full URL to your resume (e.g., a Google Drive or Dropbox link).
-                </Form.Text>
-              </Form.Group>
+              {/* Updated fields for Bento Grid */}
+              <Form.Group className="mb-3" controlId="aboutNarrative"><Form.Label>My Journey (Narrative)</Form.Label><Form.Control as="textarea" rows={5} name="aboutNarrative" value={formData.aboutNarrative || ''} onChange={handleChange} /></Form.Group>
+              <Form.Group className="mb-3" controlId="aboutSkills"><Form.Label>Core Skills</Form.Label><Form.Control as="textarea" rows={3} name="aboutSkills" value={formData.aboutSkills.join(', ')} onChange={handleSkillsChange} /><Form.Text className="text-muted">Enter skills separated by commas (e.g., React, Node.js, CSS)</Form.Text></Form.Group>
+
+              <Form.Group controlId="profilePhoto" className="mb-3"><Form.Label>Profile Photo (Headshot)</Form.Label><Form.Control type="file" onChange={uploadPhotoHandler} accept="image/*" />{uploadingPhoto && <Spinner animation="border" size="sm" className="mt-2" />}</Form.Group>
+              {formData.profilePhoto && (<div className="mb-3"><p>Current Photo:</p><Image src={formData.profilePhoto} thumbnail width="150" /><Button variant="outline-danger" size="sm" className="ms-3" onClick={handlePhotoRemove}>Remove</Button></div>)}
+              <Form.Group className="mb-3" controlId="resumeUrl"><Form.Label>Resume Link (URL)</Form.Label><Form.Control type="url" name="resumeUrl" value={formData.resumeUrl || ''} onChange={handleChange} placeholder="e.g., https://docs.google.com/document/d/..." /><Form.Text className="text-muted">Paste the full URL to your resume (e.g., a Google Drive or Dropbox link).</Form.Text></Form.Group>
               
               <Button type="submit" variant="primary">Update Profile</Button>
             </Form>

--- a/server/controllers/profileController.js
+++ b/server/controllers/profileController.js
@@ -11,7 +11,8 @@ const getProfile = asyncHandler(async (req, res) => {
     res.json({
       name: "Amaan Ahmed Shaikh",
       headline: "Enter your headline here",
-      about: "Enter your about section here",
+      aboutNarrative: "Enter your narrative here.",
+      aboutSkills: ["React", "Node.js", "MongoDB"],
       profilePhoto: "",
       resumeUrl: "",
     });
@@ -24,14 +25,15 @@ const updateProfile = asyncHandler(async (req, res) => {
     return res.status(400).json({ errors: errors.array() });
   }
 
-  const { name, headline, about, profilePhoto, resumeUrl } = req.body;
+  const { name, headline, aboutNarrative, aboutSkills, profilePhoto, resumeUrl } = req.body;
   let profile = await Profile.findOne({});
 
   if (profile) {
     // This new logic directly applies the values from the form
     profile.name = name;
     profile.headline = headline;
-    profile.about = about;
+    profile.aboutNarrative = aboutNarrative;
+    profile.aboutSkills = aboutSkills;
     profile.profilePhoto = profilePhoto;
     profile.resumeUrl = resumeUrl;
 
@@ -43,7 +45,8 @@ const updateProfile = asyncHandler(async (req, res) => {
       user: req.user._id,
       name,
       headline,
-      about,
+      aboutNarrative,
+      aboutSkills,
       profilePhoto,
       resumeUrl,
     });

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -16,11 +16,10 @@ const profileSchema = mongoose.Schema(
       type: String,
       required: true,
     },
-    about: {
+    aboutNarrative: {
       type: String,
-      required: true,
     },
-    aboutParagraphs: [
+    aboutSkills: [
       {
         type: String,
       },


### PR DESCRIPTION
This commit introduces a complete redesign of the "About Me" section, replacing the single text block with a modern and dynamic Bento Grid layout.

This comprehensive update includes:

- **Frontend Redesign:**
  - A new Bento Grid layout with cards for a headshot/intro, a narrative, and core skills.
  - Staggered fade-in animations for the cards using `framer-motion`.
  - A longer, more refined hero scroll animation.

- **Backend Update:**
  - The `Profile` model has been updated to support the new structured content, replacing the old `about` field with `aboutNarrative` and `aboutSkills`.
  - The profile controller has been updated to handle the new data structure.

- **Admin Panel Update:**
  - The profile edit page in the admin panel has been updated with new form fields to allow dynamic management of the Bento Grid content.

- **Bug Fixes:**
  - Resolves a critical bug where buttons in the "Intro" section were unclickable due to overlapping animated layers. The `pointer-events` of both the "Intro" and "About Me" sections are now orchestrated for a seamless user experience.