### PR TITLE
feat: Redesign About and Experience sections

### DIFF
--- a/client/src/components/sections/AnimatedHero.jsx
+++ b/client/src/components/sections/AnimatedHero.jsx
@@ -22,7 +22,7 @@ const AnimatedContent = ({ profile }) => {
     const introPointerEvents = useTransform(scrollYProgress, [0.19, 0.2], ['auto', 'none']);
 
     const aboutOpacity = useTransform(scrollYProgress, [0.2, 0.3, 0.8, 0.95], [0, 1, 1, 0]);
-    const aboutPointerEvents = useTransform(scrollYProgress, [0.19, 0.2, 0.95, 0.96], ['none', 'auto', 'auto', 'none']);
+    const aboutPointerEvents = useTransform(scrollYProgress, [0.2, 0.21, 0.95, 0.96], ['none', 'auto', 'auto', 'none']);
 
     return (
         <div ref={targetRef} id="home" className="animated-hero-container">

--- a/client/src/components/sections/ExperienceSection.css
+++ b/client/src/components/sections/ExperienceSection.css
@@ -1,0 +1,95 @@
+/* General Section Styling */
+.experience-section {
+    background-color: #111; /* Dark background for cohesion */
+    padding: 4rem 0;
+    color: #fff;
+}
+
+.experience-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+/* Card Styling */
+.experience-card {
+    background: rgba(20, 20, 20, 0.6);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    padding: 2rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.experience-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.experience-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1.5rem;
+}
+
+.experience-role {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.experience-company {
+    font-size: 1.1rem;
+    color: #0d6efd; /* Consistent accent color */
+    margin: 0.25rem 0 0;
+}
+
+.experience-dates {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.9);
+    padding: 0.4rem 0.8rem;
+    border-radius: 50px; /* Pill shape */
+    font-size: 0.85rem;
+    font-weight: 500;
+    flex-shrink: 0;
+}
+
+/* Description List Styling */
+.experience-description {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.experience-description li {
+    position: relative;
+    padding-left: 2rem;
+    margin-bottom: 0.75rem;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.6;
+}
+
+/* Custom Checkmark */
+.experience-description li::before {
+    content: '✔';
+    position: absolute;
+    left: 0;
+    top: 2px;
+    color: #0d6efd; /* Accent color */
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .experience-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+}

--- a/client/src/components/sections/ExperienceSection.jsx
+++ b/client/src/components/sections/ExperienceSection.jsx
@@ -1,7 +1,22 @@
 import React, { useState, useEffect } from 'react';
-import { Container, Row, Col, Alert } from 'react-bootstrap';
+import { Container, Alert } from 'react-bootstrap';
+import { motion } from 'framer-motion';
 import he from 'he';
 import { getExperiences } from '../../api/apiService';
+import './ExperienceSection.css';
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.2 },
+  },
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 50 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+};
 
 const ExperienceSection = () => {
   const [experiences, setExperiences] = useState([]);
@@ -24,36 +39,42 @@ const ExperienceSection = () => {
   }, []);
 
   return (
-    <Container id="experience" className="my-5 py-5 bg-light">
-      <h2 className="display-5 fw-bold mb-5">Professional Experience</h2>
+    <div id="experience" className="experience-section">
+      <Container>
+        <h2 className="display-5 fw-bold text-center text-white mb-5">Professional Experience</h2>
 
-      {loading ? (
-        <p>Loading experience...</p>
-      ) : error ? (
-        <Alert variant="danger">{error}</Alert>
-      ) : (
-        experiences.map((exp) => (
-          <Row key={exp._id} className="mb-4">
-            <Col md={10} lg={9}>
-              <div className="d-flex">
-                <div className="pe-4 text-muted">
-                  <strong>{he.decode(exp.dates)}</strong>
+        {loading ? (
+          <p className="text-center text-white">Loading experience...</p>
+        ) : error ? (
+          <Alert variant="danger">{error}</Alert>
+        ) : (
+          <motion.div
+            className="experience-list"
+            variants={containerVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.1 }}
+          >
+            {experiences.map((exp) => (
+              <motion.div key={exp._id} className="experience-card" variants={cardVariants}>
+                <div className="experience-header">
+                  <div>
+                    <h4 className="experience-role">{he.decode(exp.role)}</h4>
+                    <h5 className="experience-company">{he.decode(exp.company)}</h5>
+                  </div>
+                  <div className="experience-dates">{he.decode(exp.dates)}</div>
                 </div>
-                <div className="border-start ps-4">
-                  <h4>{he.decode(exp.role)}</h4>
-                  <h5 className="text-primary">{he.decode(exp.company)}</h5>
-                  <ul>
-                    {exp.description.map((point, i) => (
-                      <li key={i}>{he.decode(point)}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </Col>
-          </Row>
-        ))
-      )}
-    </Container>
+                <ul className="experience-description">
+                  {exp.description.map((point, i) => (
+                    <li key={i}>{he.decode(point)}</li>
+                  ))}
+                </ul>
+              </motion.div>
+            ))}
+          </motion.div>
+        )}
+      </Container>
+    </div>
   );
 };
 

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -18,6 +18,7 @@ const profileSchema = mongoose.Schema(
     },
     aboutNarrative: {
       type: String,
+      required: true,
     },
     aboutSkills: [
       {


### PR DESCRIPTION
This commit introduces a major redesign of the "About Me" and "Professional Experience" sections to create a more modern, cohesive, and professional portfolio.

Key changes include:

- **Bento Grid for "About Me":**
  - Replaced the single text block with a dynamic Bento Grid layout, featuring separate cards for an intro/headshot, a narrative, and core skills.
  - Implemented staggered fade-in animations for the cards using `framer-motion`.

- **Card-Based "Experience" Section:**
  - Redesigned the experience section with a card-based layout that matches the new glassmorphism aesthetic.
  - Added custom checkmarks and date pills for a more polished look.
  - Implemented staggered scroll animations for the cards.

- **Full-Stack Update for Dynamic Content:**
  - The `Profile` model on the backend was updated to support the new structured data (`aboutNarrative`, `aboutSkills`).
  - The backend API controller and the frontend admin panel were updated to allow dynamic management of the new content.

- **Critical Bug Fix:**
  - Resolved a persistent bug where buttons in the hero section were unclickable. The `pointer-events` of the overlapping animated sections are now correctly orchestrated for a seamless user experience.