### PR TITLE
feat: Complete redesign of About, Experience, and Projects sections

### DIFF
--- a/client/src/components/sections/ProjectsSection.css
+++ b/client/src/components/sections/ProjectsSection.css
@@ -1,6 +1,133 @@
+/* General Section Styling */
+.projects-section {
+    background-color: #111;
+    padding: 4rem 0;
+    color: #fff;
+}
+
+/* Grid Layout */
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+/* Project Card Styling */
+.project-card {
+    background: rgba(20, 20, 20, 0.6);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.project-card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+}
+
+.project-card-img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.project-card-body {
+    padding: 1.5rem;
+}
+
+.project-card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 0.25rem;
+}
+
+.project-card-subtitle {
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 0 0 1rem;
+}
+
+/* Technology Tags */
+.project-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.project-card-tag {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.3rem 0.75rem;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+/* Modal Styling from previous steps */
 .carousel-item img {
-  max-height: 25rem;
-  max-width: 25rem;
-  object-fit: cover; /* This prevents the image from stretching */
-  margin: auto; /* Helps center the image within the item */
+    max-height: 25rem;
+    max-width: 100%; /* Changed for better modal fit */
+    object-fit: cover;
+    margin: auto;
+}
+
+/* --- Immersive Modal Styling --- */
+.project-modal .modal-dialog {
+    max-width: 90vw; /* Almost full-screen */
+}
+
+.project-modal .modal-content {
+    background: rgba(20, 20, 20, 0.8); /* Darker, more opaque glassmorphism */
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    color: #fff;
+}
+
+.project-modal .modal-header {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.project-modal .modal-header .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%); /* Makes close button white */
+}
+
+.project-modal .modal-title {
+    font-weight: 600;
+}
+
+.project-modal .modal-body p {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 1.1rem;
+    line-height: 1.7;
+}
+
+.project-modal .modal-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    justify-content: flex-end; /* Align buttons to the right */
+    gap: 1rem;
+}
+
+/* Overriding default button styles for consistency */
+.project-modal .btn-primary {
+    background-color: #0d6efd;
+    border-color: #0d6efd;
+}
+
+.project-modal .btn-outline-dark {
+    color: #fff;
+    border-color: #fff;
+}
+
+.project-modal .btn-outline-dark:hover {
+    background-color: #fff;
+    color: #111;
 }

--- a/client/src/components/sections/ProjectsSection.jsx
+++ b/client/src/components/sections/ProjectsSection.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Container, Row, Col, Modal, Button, Alert, Carousel } from 'react-bootstrap';
-import ProjectCard from '../ProjectCard';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { getProjects } from '../../api/apiService';
 import he from 'he';
-import './ProjectsSection.css'; // Import the new CSS file
+import './ProjectsSection.css';
 
 const ProjectsSection = () => {
   const [showModal, setShowModal] = useState(false);
@@ -39,33 +38,37 @@ const ProjectsSection = () => {
     setSelectedProject(null);
   };
 
-  const groupedProjects = projects.reduce((acc, project) => {
-    (acc[project.category] = acc[project.category] || []).push(project);
-    return acc;
-  }, {});
-
   return (
-    <Container id="projects" className="my-5 py-5">
-      <h2 className="display-5 fw-bold mb-5">My Projects</h2>
-      {loading ? <p>Loading projects...</p> : error ? <Alert variant="danger">{error}</Alert> : (
-        Object.entries(groupedProjects).map(([category, projectsInCategory]) => (
-          <div key={category} className="mb-5">
-            <h3 className="mb-4">{he.decode(category)}</h3>
-            <Row xs={1} md={2} lg={3} className="g-4">
-              {projectsInCategory.map((project) => (
-                <Col key={project._id}>
-                  <ProjectCard {...project} onReadMore={() => handleShowModal(project)} />
-                </Col>
-              ))}
-            </Row>
+    <div id="projects" className="projects-section">
+      <Container>
+        <h2 className="display-5 fw-bold text-center text-white mb-5">My Projects</h2>
+        {loading ? <p className="text-center text-white">Loading projects...</p> : error ? <Alert variant="danger">{error}</Alert> : (
+          <div className="projects-grid">
+            {projects.map((project) => (
+              <div key={project._id} className="project-card" onClick={() => handleShowModal(project)}>
+                <img src={project.imageUrls[0]} alt={he.decode(project.title)} className="project-card-img" />
+                <div className="project-card-body">
+                  <h4 className="project-card-title">{he.decode(project.title)}</h4>
+                  <p className="project-card-subtitle">{he.decode(project.subtitle)}</p>
+                  <div className="project-card-tags">
+                    {project.technologies.map((tech, i) => (
+                      <span key={i} className="project-card-tag">{he.decode(tech)}</span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
-        ))
-      )}
+        )}
+      </Container>
 
       {selectedProject && (
-        <Modal show={showModal} onHide={handleCloseModal} size="lg" centered>
+        <Modal show={showModal} onHide={handleCloseModal} dialogClassName="project-modal" centered>
           <Modal.Header closeButton>
-            <Modal.Title>{he.decode(selectedProject.title)}</Modal.Title>
+            <div>
+              <Modal.Title as="h3">{he.decode(selectedProject.title)}</Modal.Title>
+              <p className="text-white-50 mb-0">{he.decode(selectedProject.subtitle)}</p>
+            </div>
           </Modal.Header>
           <Modal.Body>
             <Carousel>
@@ -75,7 +78,7 @@ const ProjectsSection = () => {
                 </Carousel.Item>
               ))}
             </Carousel>
-            <p className="mt-3">{he.decode(selectedProject.extendedDescription)}</p>
+            <p className="mt-4">{he.decode(selectedProject.extendedDescription)}</p>
           </Modal.Body>
           <Modal.Footer>
             {selectedProject.githubUrl && (
@@ -90,9 +93,6 @@ const ProjectsSection = () => {
                 Live Demo
               </Button>
             )}
-            <Button variant="secondary" onClick={handleCloseModal}>
-              Close
-            </Button>
           </Modal.Footer>
         </Modal>
       )}


### PR DESCRIPTION
This commit introduces a comprehensive redesign of the portfolio's main content sections to create a cohesive, modern, and professional user experience, based on detailed user feedback.

Key changes include:

- **Global Dark Theme:**
  - Implemented a site-wide dark theme via `index.css` for a consistent look and feel.

- **"About Me" Section (Bento Grid):**
  - Replaced the single text block with a dynamic Bento Grid layout, featuring separate cards for an intro/headshot, a narrative, and core skills.
  - Updated the backend model, controller, and admin panel to support the new structured content, including a seamless data migration for the old `about` field.

- **"Professional Experience" Section:**
  - Redesigned the section with a card-based layout using a glassmorphism effect to match the new "About Me" section.
  - Refined typography and added custom list icons for improved readability and visual hierarchy.

- **"Projects" Section:**
  - Replaced the grouped layout with a unified grid of redesigned project cards.
  - Implemented an immersive, full-screen modal for viewing project details, including a carousel for images and streamlined action buttons.

- **Animations and Interactivity:**
  - Added staggered, scroll-based fade-in animations to all new card elements for a dynamic feel.
  - Corrected a long-standing bug with button interactivity in the hero section.