### PR TITLE
feat: Redesign Education Section

### DIFF
--- a/client/src/components/sections/EducationSection.css
+++ b/client/src/components/sections/EducationSection.css
@@ -1,0 +1,66 @@
+/* Main Education Card Container */
+.education-card {
+  background: rgba(22, 22, 22, 0.75);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 3rem;
+  color: white;
+}
+
+/* Individual Education Entry */
+.education-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.education-entry:not(:last-child) {
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+
+/* Left side with icon and main info */
+.education-main-info {
+  display: flex;
+  align-items: flex-start;
+}
+
+.education-icon {
+  color: #007bff; /* Vibrant blue accent */
+  margin-right: 1.5rem;
+  margin-top: 8px;
+}
+
+.education-degree {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.education-institution {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* Right side with details */
+.education-details {
+  text-align: right;
+  flex-shrink: 0; /* Prevents shrinking */
+}
+
+.education-dates {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 0.25rem;
+}
+
+.education-cgpa {
+  font-size: 1rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+}

--- a/client/src/components/sections/EducationSection.jsx
+++ b/client/src/components/sections/EducationSection.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { Container, Row, Col, Alert } from 'react-bootstrap';
+import { Alert } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGraduationCap } from '@fortawesome/free-solid-svg-icons';
 import { getEducation } from '../../api/apiService';
 import he from 'he';
+import { motion } from 'framer-motion';
+import './EducationSection.css';
 
 const EducationSection = () => {
   const [education, setEducation] = useState([]);
@@ -11,7 +13,6 @@ const EducationSection = () => {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    // This is the logic that was missing
     const fetchEducation = async () => {
       try {
         const { data } = await getEducation();
@@ -23,29 +24,64 @@ const EducationSection = () => {
       }
     };
     fetchEducation();
-  }, []); // The empty array ensures this runs only once when the component mounts
+  }, []);
+
+  const mainCardVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.5,
+        ease: 'easeOut',
+        when: 'beforeChildren',
+        staggerChildren: 0.2,
+      },
+    },
+  };
+
+  const entryVariants = {
+    hidden: { opacity: 0, x: -20 },
+    visible: {
+      opacity: 1,
+      x: 0,
+      transition: { duration: 0.4 },
+    },
+  };
 
   return (
-    <Container id="education" className="my-5 py-5">
-      <h2 className="display-5 fw-bold mb-5">Education</h2>
-      {loading ? <p>Loading education...</p> : error ? <Alert variant="danger">{error}</Alert> : (
-        <Row>
+    <section id="education" className="my-5 py-5">
+      <h2 className="display-5 fw-bold mb-5 text-center">Education</h2>
+      {loading ? (
+        <p className="text-center">Loading education...</p>
+      ) : error ? (
+        <Alert variant="danger">{error}</Alert>
+      ) : (
+        <motion.div
+          className="education-card"
+          variants={mainCardVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2 }}
+        >
           {education.map((edu) => (
-            <Col md={10} lg={9} key={edu._id} className="mb-4">
-              <div className="d-flex align-items-start">
-                <FontAwesomeIcon icon={faGraduationCap} size="3x" className="text-primary me-4 mt-1" />
+            <motion.div className="education-entry" key={edu._id} variants={entryVariants}>
+              <div className="education-main-info">
+                <FontAwesomeIcon icon={faGraduationCap} size="3x" className="education-icon" />
                 <div>
-                  <h4 className="fw-bold">{he.decode(edu.degree)}</h4>
-                  <h5>{he.decode(edu.institution)}</h5>
-                  <p className="text-muted mb-1">{he.decode(edu.dates)}</p>
-                  <p className="text-muted"><strong>CGPA:</strong> {edu.cgpa}</p>
+                  <h4 className="education-degree">{he.decode(edu.degree)}</h4>
+                  <p className="education-institution">{he.decode(edu.institution)}</p>
                 </div>
               </div>
-            </Col>
+              <div className="education-details">
+                <p className="education-dates">{he.decode(edu.dates)}</p>
+                <p className="education-cgpa"><strong>CGPA:</strong> {edu.cgpa}</p>
+              </div>
+            </motion.div>
           ))}
-        </Row>
+        </motion.div>
       )}
-    </Container>
+    </section>
   );
 };
 


### PR DESCRIPTION
This commit redesigns the 'Education' section to align with the portfolio's modern, card-based aesthetic, using glassmorphism and subtle animations for a cohesive and polished look.

Key Changes:

-   **Unified Card Structure:** The entire section is now enclosed in a single, dark, translucent glassmorphism card, consistent with other redesigned sections.
-   **Enhanced Information Hierarchy:**
    -   The layout has been updated to create a clear visual distinction between the degree/institution and the secondary details.
    -   The degree is now the most prominent text, with the institution name styled as a secondary element.
    -   The date range and CGPA are neatly aligned to the right for better readability.
-   **"Focused Reveal" Animation:**
    -   Integrated `framer-motion` to add a gentle slide-up animation for the main card on scroll.
    -   The internal elements (degree, institution, details) now have a subtle staggered animation, creating a polished "focused reveal" effect.
-   **Code Refinements:**
    -   Created a new CSS file (`EducationSection.css`) to encapsulate the new styles.
    -   Refactored `EducationSection.jsx` to use the new card layout and animation components.