### PR TITLE
refactor: Refine Header and Certificates Section

### DIFF
--- a/client/src/components/layout/Header.css
+++ b/client/src/components/layout/Header.css
@@ -41,6 +41,7 @@
   cursor: pointer;
   padding-bottom: 0.5rem; /* Space for the indicator */
   transition: color 0.3s;
+  text-decoration: none; /* Remove underline */
 }
 
 .header-nav-link:hover,

--- a/client/src/components/sections/CertificatesSection.css
+++ b/client/src/components/sections/CertificatesSection.css
@@ -1,3 +1,8 @@
+.certificates-section-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
 /* Individual Certificate Card */
 .certificate-card {
   background: rgba(30, 30, 30, 0.75); /* Dark, semi-transparent background */

--- a/client/src/components/sections/CertificatesSection.jsx
+++ b/client/src/components/sections/CertificatesSection.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Alert, Row, Col } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCertificate } from '@fortawesome/free-solid-svg-icons';
+import { faCertificate, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import he from 'he';
 import { getCertificates } from '../../api/apiService';
 import { motion } from 'framer-motion';
@@ -57,41 +57,43 @@ const CertificatesSection = () => {
       ) : error ? (
         <Alert variant="danger">{error}</Alert>
       ) : (
-        <motion.div
-          as={Row}
-          xs={1}
-          md={2}
-          lg={2}
-          className="g-4"
-          variants={containerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.2 }}
-        >
-          {certifications.map((cert) => (
-            <motion.div as={Col} key={cert._id} variants={itemVariants}>
-              <div className="certificate-card">
-                <FontAwesomeIcon
-                  icon={faCertificate}
-                  size="3x"
-                  className="certificate-icon"
-                />
-                <h4 className="certificate-title">{he.decode(cert.title)}</h4>
-                <p className="certificate-issuer">Issued by: {he.decode(cert.issuer)}</p>
-                {cert.url && (
-                  <a
-                    href={cert.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="credential-button"
-                  >
-                    View Credential
-                  </a>
-                )}
-              </div>
-            </motion.div>
-          ))}
-        </motion.div>
+        <div className="certificates-section-container">
+          <motion.div
+            as={Row}
+            xs={1}
+            md={2}
+            lg={2}
+            className="g-4"
+            variants={containerVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            {certifications.map((cert) => (
+              <motion.div as={Col} key={cert._id} variants={itemVariants}>
+                <div className="certificate-card">
+                  <FontAwesomeIcon
+                    icon={faCertificate}
+                    size="3x"
+                    className="certificate-icon"
+                  />
+                  <h4 className="certificate-title">{he.decode(cert.title)}</h4>
+                  <p className="certificate-issuer">Issued by: {he.decode(cert.issuer)}</p>
+                  {cert.url && (
+                    <a
+                      href={cert.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="credential-button"
+                    >
+                      View Credential <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
+                    </a>
+                  )}
+                </div>
+              </motion.div>
+            ))}
+          </motion.div>
+        </div>
       )}
     </section>
   );


### PR DESCRIPTION
This commit applies final refinements to the Header and Certificates section based on user feedback, improving styling and consistency.

Key Changes:

-   **Header Refinement:**
    -   Removed the text-decoration (underline) from the header navigation links for a cleaner look.

-   **Certificates Section Refinement:**
    -   Constrained the width of the certificates section container to prevent the cards from stretching to full width on larger screens, improving the layout balance.
    -   Added a redirect arrow icon to the 'View Credential' button to maintain visual consistency with other action buttons across the portfolio.