### PR TITLE
fix: Apply dark theme to admin sidebar

### DIFF
--- a/client/src/components/layout/AdminLayout.css
+++ b/client/src/components/layout/AdminLayout.css
@@ -32,3 +32,7 @@
   font-weight: bold;
   color: #0d6efd; /* Keep primary blue for active state */
 }
+
+.admin-sidebar-title {
+  color: #fff; /* Ensure the title is white */
+}

--- a/client/src/components/layout/AdminSidebar.jsx
+++ b/client/src/components/layout/AdminSidebar.jsx
@@ -9,13 +9,13 @@ import {
     faProjectDiagram,
     faCertificate,
     faLaptopCode,
-    faTrophy // <-- NEW: Import the trophy icon
+    faTrophy
 } from '@fortawesome/free-solid-svg-icons';
 
 const AdminSidebar = () => {
     return (
-        <Nav className="flex-column bg-light vh-100 p-3 shadow-sm">
-            <h4 className="mb-4">Admin Menu</h4>
+        <Nav className="flex-column vh-100 p-3">
+            <h4 className="mb-4 admin-sidebar-title">Admin Menu</h4>
             <LinkContainer to="/admin/dashboard">
                 <Nav.Link>
                     <FontAwesomeIcon icon={faTachometerAlt} className="me-2" />
@@ -34,14 +34,12 @@ const AdminSidebar = () => {
                     Manage Experience
                 </Nav.Link>
             </LinkContainer>
-            {/* <-- NEW: Add the Achievements link --> */}
             <LinkContainer to="/admin/achievements">
                 <Nav.Link>
                     <FontAwesomeIcon icon={faTrophy} className="me-2" />
                     Manage Achievements
                 </Nav.Link>
             </LinkContainer>
-            {/* <-- Existing links --> */}
             <LinkContainer to="/admin/certificates">
                 <Nav.Link>
                     <FontAwesomeIcon icon={faCertificate} className="me-2" />


### PR DESCRIPTION
This commit corrects an oversight where the admin sidebar was not correctly styled with the new dark theme.

Key Changes:

-   **AdminSidebar.jsx:** Removed the `bg-light` Bootstrap class that was forcing a white background.
-   **AdminLayout.css:** Added a specific style to ensure the 'Admin Menu' title is white and readable against the dark background.