### PR TITLE
fix: Apply dark theme to all admin panel tables

### DIFF
--- a/client/src/pages/Admin/AchievementListPage.jsx
+++ b/client/src/pages/Admin/AchievementListPage.jsx
@@ -76,7 +76,7 @@ const AchievementListPage = () => {
         <Alert variant="danger">{error}</Alert>
       ) : (
         <DragDropContext onDragEnd={handleDragEnd}>
-          <Table striped bordered hover responsive>
+          <Table striped bordered hover responsive variant="dark">
             <thead>
               <tr>
                 <th>ORDER</th>

--- a/client/src/pages/Admin/CertificatesListPage.jsx
+++ b/client/src/pages/Admin/CertificatesListPage.jsx
@@ -58,7 +58,7 @@ const CertificatesListPage = () => {
       ) : error ? (
         <Alert variant="danger">{error}</Alert>
       ) : (
-        <Table striped bordered hover responsive>
+        <Table striped bordered hover responsive variant="dark">
           <thead>
             <tr>
               <th>TITLE</th>

--- a/client/src/pages/Admin/EducationListPage.jsx
+++ b/client/src/pages/Admin/EducationListPage.jsx
@@ -48,7 +48,7 @@ const EducationListPage = () => {
         </Col>
       </Row>
       {loading ? <p>Loading...</p> : error ? <Alert variant="danger">{error}</Alert> : (
-        <Table striped bordered hover responsive>
+        <Table striped bordered hover responsive variant="dark">
           <thead>
             <tr>
               <th>DEGREE</th>

--- a/client/src/pages/Admin/ExperienceListPage.jsx
+++ b/client/src/pages/Admin/ExperienceListPage.jsx
@@ -72,7 +72,7 @@ const ExperienceListPage = () => {
       </Row>
       {loading ? <p>Loading...</p> : error ? <Alert variant="danger">{error}</Alert> : (
         <DragDropContext onDragEnd={handleDragEnd}>
-          <Table striped bordered hover responsive>
+          <Table striped bordered hover responsive variant="dark">
             <thead>
               <tr>
                 <th>ORDER</th>

--- a/client/src/pages/Admin/ProjectListPage.jsx
+++ b/client/src/pages/Admin/ProjectListPage.jsx
@@ -73,7 +73,7 @@ const ProjectListPage = () => {
       </Row>
       {loading ? <p>Loading...</p> : error ? <Alert variant="danger">{error}</Alert> : (
         <DragDropContext onDragEnd={handleDragEnd}>
-          <Table striped bordered hover responsive>
+          <Table striped bordered hover responsive variant="dark">
             <thead>
               <tr>
                 <th>ORDER</th>

--- a/client/src/pages/Admin/SkillsListPage.jsx
+++ b/client/src/pages/Admin/SkillsListPage.jsx
@@ -58,7 +58,7 @@ const SkillsListPage = () => {
       ) : error ? (
         <Alert variant="danger">{error}</Alert>
       ) : (
-        <Table striped bordered hover responsive>
+        <Table striped bordered hover responsive variant="dark">
           <thead>
             <tr>
               <th>CATEGORY</th>


### PR DESCRIPTION
This commit fixes a persistent bug where tables in the admin panel were not correctly styled with the dark theme.

Key Changes:

-   **Admin List Pages:**
    -   Applied the `variant="dark"` prop to the `Table` component on all list pages (`Projects`, `Achievements`, `Certificates`, `Education`, `Experience`, `Skills`).
    -   This uses the intended `react-bootstrap` method for dark-themed tables, ensuring a consistent and robust implementation that correctly styles the table background, text, borders, and hover/striped states.
    -   This replaces the previous, less reliable CSS override attempts.