### PR TITLE
Fix UI robustness and admin panel decoding bugs

### DIFF
--- a/client/src/components/sections/AchievementsSection.css
+++ b/client/src/components/sections/AchievementsSection.css
@@ -35,4 +35,5 @@
   font-size: 1rem;
   color: rgba(255, 255, 255, 0.7); /* Lighter gray for supporting text */
   line-height: 1.6;
+  word-wrap: break-word; /* Prevent overflow from long strings */
 }

--- a/client/src/components/sections/CertificatesSection.css
+++ b/client/src/components/sections/CertificatesSection.css
@@ -32,12 +32,14 @@
   color: #ffffff;
   flex-grow: 1; /* Pushes button to the bottom */
   margin-bottom: 0.5rem;
+  word-wrap: break-word; /* Prevent overflow from long strings */
 }
 
 .certificate-issuer {
   font-size: 0.9rem;
   color: rgba(255, 255, 255, 0.6);
   margin-bottom: 1.5rem;
+  word-wrap: break-word; /* Prevent overflow from long strings */
 }
 
 /* Action Button */

--- a/client/src/components/sections/EducationSection.css
+++ b/client/src/components/sections/EducationSection.css
@@ -42,11 +42,13 @@
   font-size: 1.5rem;
   font-weight: 700;
   color: #ffffff;
+  word-wrap: break-word; /* Prevent overflow from long strings */
 }
 
 .education-institution {
   font-size: 1.1rem;
   color: rgba(255, 255, 255, 0.7);
+  word-wrap: break-word; /* Prevent overflow from long strings */
 }
 
 /* Right side with details */

--- a/client/src/components/sections/ExperienceSection.css
+++ b/client/src/components/sections/ExperienceSection.css
@@ -72,6 +72,7 @@
     margin-bottom: 1rem; /* Increased spacing */
     color: rgba(255, 255, 255, 0.75);
     line-height: 1.7; /* Increased line height for readability */
+    word-wrap: break-word; /* Prevent overflow from long strings */
 }
 
 /* Custom, more subtle list icon */

--- a/client/src/pages/Admin/AchievementListPage.jsx
+++ b/client/src/pages/Admin/AchievementListPage.jsx
@@ -5,6 +5,7 @@ import { getAchievements, deleteAchievement, reorderAchievements } from '../../a
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faArrowsAlt } from '@fortawesome/free-solid-svg-icons';
+import he from 'he';
 
 const AchievementListPage = () => {
   const [achievements, setAchievements] = useState([]);
@@ -93,8 +94,8 @@ const AchievementListPage = () => {
                       {(draggableProvided) => (
                         <tr ref={draggableProvided.innerRef} {...draggableProvided.draggableProps} {...draggableProvided.dragHandleProps}>
                           <td><FontAwesomeIcon icon={faArrowsAlt} className="me-2 text-muted" />{index + 1}</td>
-                          <td>{achievement.title}</td>
-                          <td>{achievement.description}</td>
+                          <td>{he.decode(achievement.title)}</td>
+                          <td>{he.decode(achievement.description)}</td>
                           <td>
                             <LinkContainer to={`/admin/achievements/${achievement._id}/edit`}>
                               <Button variant="light" className="btn-sm mx-1">

--- a/client/src/pages/Admin/CertificatesListPage.jsx
+++ b/client/src/pages/Admin/CertificatesListPage.jsx
@@ -4,6 +4,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { getCertificates, deleteCertificate } from '../../api/apiService';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import he from 'he';
 
 const CertificatesListPage = () => {
   const [certificates, setCertificates] = useState([]);
@@ -69,8 +70,8 @@ const CertificatesListPage = () => {
           <tbody>
             {certificates.map((cert) => (
               <tr key={cert._id}>
-                <td>{cert.title}</td>
-                <td>{cert.issuer}</td>
+                <td>{he.decode(cert.title)}</td>
+                <td>{he.decode(cert.issuer)}</td>
                 <td>
                   <LinkContainer to={`/admin/certificates/${cert._id}/edit`}>
                     <Button variant="light" className="btn-sm mx-1">

--- a/client/src/pages/Admin/EducationListPage.jsx
+++ b/client/src/pages/Admin/EducationListPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Container, Table, Alert, Button, Row, Col } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { getEducation, deleteEducation } from '../../api/apiService';
+import he from 'he';
 
 const EducationListPage = () => {
   const [educationList, setEducationList] = useState([]);
@@ -59,8 +60,8 @@ const EducationListPage = () => {
           <tbody>
             {educationList.map((edu) => (
               <tr key={edu._id}>
-                <td>{edu.degree}</td>
-                <td>{edu.institution}</td>
+                <td>{he.decode(edu.degree)}</td>
+                <td>{he.decode(edu.institution)}</td>
                 <td>
                   <LinkContainer to={`/admin/education/${edu._id}/edit`}>
                     <Button variant="light" className="btn-sm mx-1">Edit</Button>

--- a/client/src/pages/Admin/ExperienceListPage.jsx
+++ b/client/src/pages/Admin/ExperienceListPage.jsx
@@ -5,6 +5,7 @@ import { getExperiences, deleteExperience, reorderExperiences } from '../../api/
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faArrowsAlt } from '@fortawesome/free-solid-svg-icons';
+import he from 'he';
 
 const ExperienceListPage = () => {
   const [experiences, setExperiences] = useState([]);
@@ -90,9 +91,9 @@ const ExperienceListPage = () => {
                       {(draggableProvided) => (
                         <tr ref={draggableProvided.innerRef} {...draggableProvided.draggableProps} {...draggableProvided.dragHandleProps}>
                           <td><FontAwesomeIcon icon={faArrowsAlt} className="me-2 text-muted" />{index + 1}</td>
-                          <td>{exp.role}</td>
-                          <td>{exp.company}</td>
-                          <td>{exp.dates}</td>
+                          <td>{he.decode(exp.role)}</td>
+                          <td>{he.decode(exp.company)}</td>
+                          <td>{he.decode(exp.dates)}</td>
                           <td>
                             <LinkContainer to={`/admin/experiences/${exp._id}/edit`}>
                               <Button variant="light" className="btn-sm mx-1">

--- a/client/src/pages/Admin/ProjectListPage.jsx
+++ b/client/src/pages/Admin/ProjectListPage.jsx
@@ -5,6 +5,7 @@ import { getProjects, deleteProject, reorderProjects } from '../../api/apiServic
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faArrowsAlt } from '@fortawesome/free-solid-svg-icons';
+import he from 'he';
 
 const ProjectListPage = () => {
   const [projects, setProjects] = useState([]);
@@ -90,8 +91,8 @@ const ProjectListPage = () => {
                       {(draggableProvided) => (
                         <tr ref={draggableProvided.innerRef} {...draggableProvided.draggableProps} {...draggableProvided.dragHandleProps}>
                           <td><FontAwesomeIcon icon={faArrowsAlt} className="me-2 text-muted" />{index + 1}</td>
-                          <td>{project.title}</td>
-                          <td>{project.category}</td>
+                          <td>{he.decode(project.title)}</td>
+                          <td>{he.decode(project.category)}</td>
                           <td>
                             <LinkContainer to={`/admin/projects/${project._id}/edit`}>
                               <Button variant="light" className="btn-sm mx-1">Edit</Button>

--- a/client/src/pages/Admin/SkillsListPage.jsx
+++ b/client/src/pages/Admin/SkillsListPage.jsx
@@ -4,6 +4,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { getSkills, deleteSkill } from '../../api/apiService';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import he from 'he';
 
 const SkillsListPage = () => {
   const [skills, setSkills] = useState([]);
@@ -69,8 +70,8 @@ const SkillsListPage = () => {
           <tbody>
             {skills.map((skill) => (
               <tr key={skill._id}>
-                <td>{skill.title}</td>
-                <td>{skill.skills.join(', ')}</td>
+                <td>{he.decode(skill.title)}</td>
+                <td>{skill.skills.map(s => he.decode(s)).join(', ')}</td>
                 <td>
                   <LinkContainer to={`/admin/skills/${skill._id}/edit`}>
                     <Button variant="light" className="btn-sm mx-1">


### PR DESCRIPTION
This commit addresses two separate issues:

1.  **UI Text Overflow:**
    - Adds `word-wrap: break-word;` to several components in the public-facing portfolio (`Experience`, `Achievements`, `Certificates`, `Education`).
    - This prevents long, unbreakable strings (like URLs) from overflowing their containers and breaking the layout, making the UI more robust.

2.  **Admin Panel HTML Entity Decoding:**
    - Fixes a bug in all admin list pages where text containing HTML entities was not being decoded before rendering.
    - This ensures that data (e.g., titles, descriptions, categories) is displayed correctly and consistently across the admin panel, matching the behavior of the 'edit' pages.